### PR TITLE
Use TLS Ingress because not using .greenpeace.org #1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ job_environments:
     WP_DB_NAME: planet4-switzerl_wordpress_develop
     WP_STATELESS_BUCKET: planet4-switzerland-stateless-develop
     INGRESS_TLS: true
-    INGRESS_NOTTLS: false
+    INGRESS_NOTLS: false
   release_build_env: &release_build_env
     GOOGLE_PROJECT_ID: planet4-production
   release_environment: &release_environment
@@ -47,7 +47,7 @@ job_environments:
     WP_DB_NAME: planet4-switzerl_wordpress_release
     WP_STATELESS_BUCKET: planet4-switzerland-stateless-release
     INGRESS_TLS: true
-    INGRESS_NOTTLS: false
+    INGRESS_NOTLS: false
   production_environment: &production_environment
     APP_HOSTNAME: www.greenpeace.ch
     CLOUDSQL_INSTANCE: planet4-prod
@@ -58,7 +58,7 @@ job_environments:
     WP_DB_NAME: planet4-switzerl_wordpress_master
     WP_STATELESS_BUCKET: planet4-switzerland-stateless
     INGRESS_TLS: true
-    INGRESS_NOTTLS: false
+    INGRESS_NOTLS: false
 
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ job_environments:
     HELM_RELEASE: planet4-switzerland
     WP_DB_NAME: planet4-switzerl_wordpress_develop
     WP_STATELESS_BUCKET: planet4-switzerland-stateless-develop
+    INGRESS_TLS: true
+    INGRESS_NOTTLS: false
   release_build_env: &release_build_env
     GOOGLE_PROJECT_ID: planet4-production
   release_environment: &release_environment
@@ -44,6 +46,8 @@ job_environments:
     HELM_RELEASE: planet4-switzerland-release
     WP_DB_NAME: planet4-switzerl_wordpress_release
     WP_STATELESS_BUCKET: planet4-switzerland-stateless-release
+    INGRESS_TLS: true
+    INGRESS_NOTTLS: false
   production_environment: &production_environment
     APP_HOSTNAME: www.greenpeace.ch
     CLOUDSQL_INSTANCE: planet4-prod
@@ -53,6 +57,8 @@ job_environments:
     HELM_RELEASE: planet4-switzerland-master
     WP_DB_NAME: planet4-switzerl_wordpress_master
     WP_STATELESS_BUCKET: planet4-switzerland-stateless
+    INGRESS_TLS: true
+    INGRESS_NOTTLS: false
 
 
 commands:


### PR DESCRIPTION
Because switzerland is using greenpeace.ch and not using greenpeace.org we need to generate certificates for this domain. Changing these parameters will deploy an ingress resource that will automatically generate certs for this domain.