### PR TITLE
Increase memory limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ job_environments:
     HELM_RELEASE: planet4-switzerland-master
     WP_DB_NAME: planet4-switzerl_wordpress_master
     WP_STATELESS_BUCKET: planet4-switzerland-stateless
+    PHP_MEMORY_LIMIT: 2Gi
 
 
 commands:


### PR DESCRIPTION
Due to slowdowns and intermittent outages caused by memory exhaustion from spam attacks. Increase the memory limit associated with GP switzerland.