### PR TITLE
Add media library plugin

### DIFF
--- a/composer-local.json
+++ b/composer-local.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "require": {
         "greenpeace/planet4-child-theme-switzerland" : "1.*",
+        "greenpeace/planet4-plugin-medialibrary" : "v1.16",
         "wpackagist-plugin/wp-mail-smtp": "3.8.*",
         "greenpeace/planet4-gpch-plugin-blocks": "1.*",
         "greenpeace/planet4-gpch-plugin-tamaro": "1.*",


### PR DESCRIPTION
We are about to remove this plugin from all websites in favor of the new implementation. 

Since the implementation is integrated into the master-theme and you are using an older version, we can add the plugin definition here temporarily so we keep importing media.