### PR TITLE
Retire P4 blocks plugin

### DIFF
--- a/development.json
+++ b/development.json
@@ -1,7 +1,6 @@
 {
   "require": {
     "greenpeace/planet4-master-theme" : "dev-main",
-    "greenpeace/planet4-plugin-gutenberg-blocks": "dev-main",
     "greenpeace/planet4-child-theme-switzerland" : "dev-master",
     "greenpeace/planet4-gpch-plugin-blocks": "dev-master",
     "greenpeace/planet4-gpch-plugin-tamaro": "dev-develop",

--- a/production.json
+++ b/production.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "greenpeace/planet4-master-theme" : "v1.312.0",
-        "greenpeace/planet4-plugin-gutenberg-blocks": "v1.109.0"
+        "greenpeace/planet4-master-theme" : "v1.312.0"
     }
 }


### PR DESCRIPTION
As we retired the plugin (already [removed](https://github.com/greenpeace/planet4-base/commit/c478d15675901844079637d8def2032c3d594473) from base repo), feel free to remove its definition completely from composer requirements.